### PR TITLE
feat: gather information about the step definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cucumber-steps-parser",
-    "version": "2.1.0",
+    "version": "3.0.0",
     "description": "A parser to get the cucumber sentences from step definition files",
     "repository": {
         "type": "git",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import { argv } from 'yargs';
 import { getFolderCucumberSentences } from './lib/cucumber-sentences';
 
-const path = argv._[0] as string | undefined;
+const path = argv._[0];
 const recursive = argv.recursive as boolean | undefined;
 const filenameRegExp = argv.filename as string | undefined;
 
@@ -15,7 +15,7 @@ E.g. cucumber-steps-parser /c/company-name/project`);
             filenameRegExp,
             recursive
         });
-        console.log(sentences);
+        console.log(JSON.stringify(sentences, null, 4));
     } catch (error) {
         console.log(error);
         process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { getFileCucumberSentences, getFolderCucumberSentences, ICucumberStepDetails as CucumberStepDetails } from './lib/cucumber-sentences';
+export { getFileCucumberSentences, getFolderCucumberSentences, ICucumberStepDetails } from './lib/cucumber-sentences';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { getFileCucumberSentences, getFolderCucumberSentences } from './lib/cucumber-sentences';
+export { getFileCucumberSentences, getFolderCucumberSentences, ICucumberStepDetails as CucumberStepDetails } from './lib/cucumber-sentences';

--- a/src/lib/__step-definitions__/cucumber-sentences.step.ts
+++ b/src/lib/__step-definitions__/cucumber-sentences.step.ts
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { Given, Then, When } from 'cucumber';
 import { resolve } from 'path';
-import { getFileCucumberSentences, getFolderCucumberSentences } from '../cucumber-sentences';
+import { ICucumberStepDetails, getFileCucumberSentences, getFolderCucumberSentences } from '../cucumber-sentences';
 
 let filePath: string;
 let folderPath: string;
-let sentences: string[];
+let sentences: ICucumberStepDetails[];
 
 const flattenArray = (array: any[][]) => {
     return array.reduce((flattened, next) => flattened.concat(next), []);
@@ -15,7 +15,7 @@ Given(/^the file "([^.]+\.ts)" \(inside the sentences-files folder\)$/, (fileNam
     filePath = resolve(__dirname, '..', '..', '..', 'features', 'sentences-files', fileName);
 });
 
-Given(/^the folder "(.*)" \(inside the sentences-files folder\)$/, (folderName: string) => {
+Given(/^the folder "(.*)" \(inside the sentences-files folder\)$/, function (folderName: string) {
     folderPath = resolve(__dirname, '..', '..', '..', 'features', 'sentences-files', folderName);
 });
 
@@ -40,11 +40,11 @@ When(
     }
 );
 
-Then(/^no cucumber sentences are returned$/, () => {
-    expect(sentences).to.deep.equal([]);
+Then('no cucumber sentences are returned', () => {
+    expect(sentences.map(s => s.text)).to.deep.equal([]);
 });
 
-Then(/^the following cucumber sentences are returned$/, dataTable => {
+Then(`the following cucumber sentences are returned`, dataTable => {
     const expectedSentences = flattenArray(dataTable.rawTable);
-    expect(sentences).to.deep.equal(expectedSentences);
+    expect(sentences.map(s => s.text)).to.deep.equal(expectedSentences);
 });

--- a/src/lib/cucumber-sentences.ts
+++ b/src/lib/cucumber-sentences.ts
@@ -1,62 +1,88 @@
 import { existsSync, lstatSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
-import typescript from 'typescript';
+import ts from 'typescript';
+
+const getTagsFromStatement = (statement: ts.Statement, sourceFile: ts.SourceFile): string[] => {
+    const tags: string[] = [];
+    const jsDocArray = (statement as any).jsDoc;
+    if (jsDocArray && Array.isArray(jsDocArray)) {
+        jsDocArray.filter(jsDoc => ts.isJSDoc(jsDoc) && jsDoc.tags).forEach((jsDoc: ts.JSDoc) => {
+            jsDoc.tags.forEach(t => {
+                tags.push(t.tagName.getText(sourceFile));
+            });
+        });
+    }
+
+    return tags;
+}
+
+const getStepDefinitionText = (callExpression: ts.CallExpression, sourceFile: ts.SourceFile): { raw: string, formatted: string } => {
+    const argument = callExpression.arguments[0];
+    const stepDefinitionText = argument.getText(sourceFile);
+    const raw = stepDefinitionText;
+    if (ts.isRegularExpressionLiteral(argument)) {
+        return {
+            formatted: stepDefinitionText.replace(/^\/\^?/, '')
+                .replace(/\$?\/$/, '')
+                .replace(/\\"/g, '"')
+                .replace(/\\'/g, "'"),
+            raw,
+        };
+    }
+
+    if (ts.isStringLiteral(argument) || ts.isNoSubstitutionTemplateLiteral(argument)) {
+        return { formatted: argument.text, raw: argument.text, };
+    }
+
+    return { formatted: raw, raw };
+}
+
+const getArguments = (callExpression: ts.CallExpression, sourceFile: ts.SourceFile): string[] => {
+    const functionDeclaration = callExpression.arguments[1];
+
+    if (!functionDeclaration || !ts.isFunctionLike(functionDeclaration)) {
+        return [];
+    }
+    return functionDeclaration.parameters.map(p => p.name.getText(sourceFile));
+}
+
+export interface ICucumberStepDetails {
+    text: string;
+    rawText: string;
+    tags: string[];
+    args: string[];
+}
 
 export const getFileCucumberSentences = (filePath: string) => {
-    const sourceFile = typescript.createSourceFile(
+    const sourceFile = ts.createSourceFile(
         'N/A',
         readFileSync(filePath).toString(),
-        typescript.ScriptTarget.ESNext,
+        ts.ScriptTarget.ESNext,
         false
     );
 
-    const cucumberStatements = sourceFile.statements.filter(statement => {
-        const expression = (statement as any).expression;
-        return (
-            expression &&
-            expression.expression &&
-            expression.expression.escapedText &&
-            expression.expression.escapedText.match(/^(Given|When|Then)$/)
-        );
+    const cucumberStatements: ICucumberStepDetails[] = []
+    sourceFile.statements.forEach(statement => {
+        if (
+            !ts.isExpressionStatement(statement) ||
+            !ts.isCallExpression(statement.expression) ||
+            statement.expression.arguments.length === 0 ||
+            !statement.expression.expression.getText(sourceFile).match(/^(Given|When|Then)$/)
+        ) {
+            return;
+        }
+
+        const tags = getTagsFromStatement(statement, sourceFile);
+
+        const text = getStepDefinitionText(statement.expression, sourceFile);
+
+        const args = getArguments(statement.expression, sourceFile);
+
+        cucumberStatements.push({ tags, args, rawText: text.raw, text: text.formatted });
+
     });
 
-    const cucumberSentences = cucumberStatements.reduce(
-        (reduced, statement) => {
-            const sentences: string[] = [];
-            statement.forEachChild(child => {
-                if (child.kind === typescript.SyntaxKind.CallExpression) {
-                    const _arguments = (child as any).arguments;
-
-                    const stringArguments = _arguments
-                        .filter(
-                            (argument: any) =>
-                                argument.kind === typescript.SyntaxKind.StringLiteral ||
-                                argument.kind === typescript.SyntaxKind.FirstTemplateToken
-                        )
-                        .map((argument: any) => argument.text);
-                    sentences.push(...stringArguments);
-
-                    const regexArguments = _arguments
-                        .filter(
-                            (argument: any) =>
-                                argument.kind === typescript.SyntaxKind.RegularExpressionLiteral
-                        )
-                        .map((argument: any) =>
-                            argument.text
-                                .replace(/^\/\^?/, '')
-                                .replace(/\$?\/$/, '')
-                                .replace(/\\"/g, '"')
-                                .replace(/\\'/g, "'")
-                        );
-                    sentences.push(...regexArguments);
-                }
-            });
-            return reduced.concat(sentences);
-        },
-        [] as string[]
-    );
-
-    return cucumberSentences;
+    return cucumberStatements;
 };
 
 export interface ICrawlingOptions {
@@ -73,7 +99,7 @@ export interface ICrawlingOptions {
 export const getFolderCucumberSentences = (
     folderPath: string,
     options: ICrawlingOptions = {}
-): string[] => {
+): ICucumberStepDetails[] => {
     if (!existsSync(folderPath) || !lstatSync(folderPath).isDirectory()) {
         console.log(`No directory was found at ${folderPath}`);
         return [];
@@ -82,7 +108,7 @@ export const getFolderCucumberSentences = (
     const recursiveCrawling = options.recursive === undefined || options.recursive;
     const filenameRegExp = new RegExp(options.filenameRegExp || '^.*\\.ts$');
 
-    return readdirSync(folderPath).reduce<string[]>((all, nextItem) => {
+    return readdirSync(folderPath).reduce<ICucumberStepDetails[]>((all, nextItem) => {
         const itemPath = join(folderPath, nextItem);
         const isDirectoryItem = lstatSync(itemPath).isDirectory();
 
@@ -90,8 +116,8 @@ export const getFolderCucumberSentences = (
             isDirectoryItem && recursiveCrawling
                 ? getFolderCucumberSentences(itemPath, options)
                 : !isDirectoryItem && nextItem.match(filenameRegExp)
-                ? getFileCucumberSentences(itemPath)
-                : [];
+                    ? getFileCucumberSentences(itemPath)
+                    : [];
         return all.concat(sentences);
     }, []);
 };

--- a/src/lib/cucumber-sentences.ts
+++ b/src/lib/cucumber-sentences.ts
@@ -67,6 +67,7 @@ export const getFileCucumberSentences = (filePath: string) => {
             !ts.isExpressionStatement(statement) ||
             !ts.isCallExpression(statement.expression) ||
             statement.expression.arguments.length === 0 ||
+            !statement.expression.expression.getText(sourceFile) ||
             !statement.expression.expression.getText(sourceFile).match(/^(Given|When|Then)$/)
         ) {
             return;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
         "moduleResolution": "node",
         "noImplicitAny": true,
         "outDir": "./dist/",
-        "target": "es6"
+        "target": "es6",
+        "sourceMap": true,
     },
     "include": ["src"],
     "exclude": ["src/**/__step-definitions__"],


### PR DESCRIPTION
Hi @capelski ,

I hope this PR finds you well.

I made some modifications to your amazing library, now it not only provides a list of step definitions, but also more information about them! For example:

- Any tags form JSDoc, e.g `@deprecated`,
- List of the argument names that the step definition function has
- Raw, unformatted step definition

Example of the result:
```
[
    {
        "tags": [],
        "args": [
            "fileName"
        ],
        "rawText": "/^the file \"([^.]+\\.ts)\" \\(inside the sentences-files folder\\)$/",
        "text": "the file \"([^.]+\\.ts)\" \\(inside the sentences-files folder\\)"
    },
    {
        "tags": [
            "folderName"
        ],
        "args": [
            "deprecated"
        ],
        "rawText": "/^the folder \"(.*)\" \\(inside the sentences-files folder\\)$/",
        "text": "the folder \"(.*)\" \\(inside the sentences-files folder\\)"
    },
    {
        "tags": [],
        "args": [],
        "rawText": "/^the cucumber sentences defined in the file are required$/",
        "text": "the cucumber sentences defined in the file are required"
    },
....
``` 

I also bumped the version to `3.0.0` as this is a breaking change. 